### PR TITLE
Prevent publishing to npm with `private` key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "amp-server",
   "version": "1.0.0",
   "description": "",


### PR DESCRIPTION
Towards #27 

> :warning: In the short term, I would also recommend we add a `"private": true` flag into the `package.json` to prevent accidental publishing to npm for those of us with local-and-active npm credentials. 😅

This PR does ☝🏻 as a short term solution to preventing anyone from accidentally publishing this currently private repository to npm. 📦 

From the [npm docs](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#private):

> If you set `"private": true` in your package.json, then npm will refuse to publish it.
>
> This is a way to prevent accidental publication of private repositories. ...