### PR TITLE
Dependency cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "airtable": "^0.10.1",
         "axios": "^0.21.1",
-        "body-parser": "^1.19.0",
         "cors": "^2.8.5",
         "dotenv": "^8.2.0",
         "express": "^4.17.1"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "airtable": "^0.10.1",
     "axios": "^0.21.1",
-    "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1"

--- a/server/app.js
+++ b/server/app.js
@@ -1,11 +1,10 @@
 require("dotenv").config();
 const express = require("express");
-//const bodyParser = require("body-parser");
 const cors = require("cors");
 const app = express();
 
 //Middleware
-//app.use(bodyParser.json());
+//app.use(express.json());
 app.use(cors());
 
 const amplify = require('./routes/api/amplify');


### PR DESCRIPTION
### What Changed

- Moved `jest` and `supertest` from `dependencies` to `devDependencies` since they are not needed to run the application in production
- Removed the `body-parser` middleware dependency
  - This Express middleware was made available in core Express v4.16.0 onwards, so we can now just use [`express.json(...)`](http://expressjs.com/en/4x/api.html#express.json) and friends.

### Outstanding Question

We also have a dependency on `airtable` right now, which we don't seem to be using as of yet. I didn't go so far as removing that dependency since I don't yet know if we have plans to begin using it in the near future. 🤔 