### PR TITLE
Reintroduce accidentally deleted Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew "node"
+brew "postgresql"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -7,8 +7,8 @@ command -v brew >/dev/null 2>&1 || {
   bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 }
 
-echo "==> Upgrading Homebrew..."
-brew upgrade
+echo "==> Updating Homebrew..."
+brew update
 
 brew bundle check >/dev/null 2>&1 || {
   echo "==> Installing Homebrew dependencies..."


### PR DESCRIPTION
The `Brewfile` was deleted in https://github.com/ProgramEquity/amplify-back-end/pull/67 

I suspect @teakopp was trying to delete `Brewfile.lock.json` but accidentally ended up with just `Brewfile` when doing tab-completion or something. 🤔 

Anyway, AFAIK, this file should definitely still be present. 😅 