### PR TITLE
Add a Dependabot config to receive update PRs monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 20 # default is 5
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10 # default is 5


### PR DESCRIPTION
This will give us control over Dependabot beyond the default security updates that it does.

This PR introduces on configuration for npm dependencies as well as GitHub Actions that appear in our Workflows' `uses` statements.

Simply having this file in the repo will a wake up Dependabot, and will continue to do attempts at security updates as well. 🤖 🚀 