### PR TITLE
Update check to the current GitHub organization name

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test:
-    if: ${{ github.repository == 'Ally-Guide/amplify-back-end' }}
+    if: ${{ github.repository == 'ProgramEquity/amplify-back-end' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
We renamed our org from `Ally-Guide` to `ProgramEquity`. ➡️ 