### PR TITLE
Remove stray `console.log` statements

### DIFF
--- a/server/routes/api/lob.js
+++ b/server/routes/api/lob.js
@@ -204,8 +204,6 @@ function getLobApiKey() {
   const { LOB_API_KEY, LiveLob } = process.env
   const lobApiKey = LOB_API_KEY || LiveLob
 
-  console.log({ lobApiKey })
-
   if (LiveLob) {
     if (LOB_API_KEY) {
       console.warn('Using "LOB_API_KEY" environment variable.')

--- a/server/routes/api/representatives.js
+++ b/server/routes/api/representatives.js
@@ -69,7 +69,6 @@ router.get('/:zipCode', async (req, res) => {
               repInfo.twitter = twitter.id
             }
           }
-          console.log(repInfo)
           congressMembers.push(repInfo)
         })
       })


### PR DESCRIPTION
The API key, especially, should not be leaked into our logs. 😬 😅 