### PR TITLE
Drop unique requirement for `template_id` column in `letter_versions` table

### DIFF
--- a/server/db/migrations/20211230165827_harden-letter_versions-table.js
+++ b/server/db/migrations/20211230165827_harden-letter_versions-table.js
@@ -17,9 +17,7 @@ module.exports = {
 
       // Add indexes
       table.index(['campaign_id'])
-
-      // Add unique indexes
-      table.unique(['template_id'])
+      table.index(['template_id'])
     })
   },
 
@@ -35,9 +33,7 @@ module.exports = {
 
       // Drop indexes
       table.dropIndex(['campaign_id'])
-
-      // Drop unique indexes
-      table.dropUnique(['template_id'])
+      table.dropIndex(['template_id'])
     })
 
     await knex.schema.alterTable(tableName, function (table) {


### PR DESCRIPTION
Ran into some unexpected migration failures when running #147 against the production database. 😖 